### PR TITLE
Remove director

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,3 @@
-director: dneufeld
 owners:
 - Shopify/dev-infra
 classification: tier4


### PR DESCRIPTION
**Owners**: @Shopify/dev-infra
**Service**: [ruby-bench-web/production](https://services.shopify.io/services/ruby-bench-web/production)
**App**: [shopify-rubybench](https://dashboard.heroku.com/apps/shopify-rubybench)

Director ownership has been deprecated in favour of Product/Service Line ownership.

For more information on service ownership, you can read the docs in [Services DB](https://services.shopify.io/doc/ownership).
